### PR TITLE
Corrige seção de números negativos no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ extenso('42', { mode: 'currency' }) // 'quarenta e dois reais'
 ##### Exemplo
 
 ```js
-extenso('42') // 'quarenta e dois negativo'
-extenso('42', { negative: 'formal' }) // 'quarenta e dois negativo'
-extenso('42', { negative: 'informal' }) // 'menos quarenta e dois'
+extenso('-42') // 'quarenta e dois negativo'
+extenso('-42', { negative: 'formal' }) // 'quarenta e dois negativo'
+extenso('-42', { negative: 'informal' }) // 'menos quarenta e dois'
 ```
 
 #### `locale`


### PR DESCRIPTION
Corrige as informações de documentação para números negativos no README:

```js
extenso('42') // 'quarenta e dois negativo'
```

deveria ser:

```js
extenso('-42') // 'quarenta e dois negativo'
```