### PR TITLE
Consertando erro "de reais" em monetário acima de 1mi

### DIFF
--- a/src/write-all.test.js
+++ b/src/write-all.test.js
@@ -61,9 +61,8 @@ test('Deve escrever conforme a escala desejada', (t) => {
   t.is(writeAll('2.000.000.001', { scale: 'long' }), 'dois mil milhões e um')
   t.is(writeAll('2.000.000.001', { scale: 'long', number: { gender: 'f' } }), 'duas mil milhões e uma')
 
-  // "de reais"???
-  t.is(writeAll('2.000.000.001', { mode: 'currency', scale: 'short' }), 'dois bilhões e um de reais')
-  t.is(writeAll('2.000.000.001', { mode: 'currency', scale: 'long' }), 'dois mil milhões e um de reais')
+  t.is(writeAll('2.000.000.001', { mode: 'currency', scale: 'short' }), 'dois bilhões e um reais')
+  t.is(writeAll('2.000.000.001', { mode: 'currency', scale: 'long' }), 'dois mil milhões e um reais')
 })
 
 test('Deve verificar se uma opção é válida', (t) => {

--- a/src/write-currency/index.test.js
+++ b/src/write-currency/index.test.js
@@ -16,6 +16,7 @@ test('Deve escrever valores monetários por extenso', (t) => {
   t.is(writeCurrency('BRL', 'br', '0', '05'),       'cinco centavos')
   t.is(writeCurrency('BRL', 'br', undefined, '25'), 'vinte e cinco centavos')
   t.is(writeCurrency('BRL', 'br', '1000000'),       'um milhão de reais')
+  t.is(writeCurrency('BRL', 'br', '1000011'),       'um milhão e onze reais')
   t.is(writeCurrency('BRL', 'br', '2000000', '50'), 'dois milhões de reais e cinquenta centavos')
 
   // Testes com o ESCUDO

--- a/src/write-currency/write.js
+++ b/src/write-currency/write.js
@@ -14,7 +14,15 @@ export default (val, locale, opts, scale) => {
   const text = writeInt(val, locale, 'm', scale)
 
   if (number === 1) return `${text} ${opts.singular}`
-  if (number >= 1e+6) return `${text} de ${opts.plural}`
+  if (number >= 1e+6) {
+    const numStr = number.toString()
+    const hundreds = parseInt(numStr.substr(-6, 3))
+    const dozens = parseInt(numStr.substr(-3, 3))
+
+    if (hundreds === 0 && dozens === 0) {
+      return `${text} de ${opts.plural}`
+    }
+  }
 
   return `${text} ${opts.plural}`
 }


### PR DESCRIPTION
closes #38

O PortuJS inteiro é muito interessante e bem nas minhas ideias de conteúdos BR, conheci a partir do [awesome-made-by-brazilians](https://github.com/felipefialho/awesome-made-by-brazilians).

Estava de olho e por causa da organização consegui entender o código e bug bem rápido e atualizar testes.
Tenso que é polêmico e levanta outras questões de escrita como essa diferença no plural do "2.000.000.001":
[Conversor de Medidas](https://conversor-de-medidas.com/mis/por-extenso/_2000000001)
[Clevert](https://clevert.com.br/t/pt-br/numbers-to-words/index/pt-br/2000001)