### PR TITLE
Corrige erro ao escrever valores monetários com decimais

### DIFF
--- a/src/num-util.test.js
+++ b/src/num-util.test.js
@@ -40,6 +40,6 @@ test('Deve analisar um número (separador decimal = .)', (t) => {
   t.deepEqual(parseNumber('-42,000.42', true), { isNegative: true, integer: '42000', decimal: '42' })
 })
 
-test('Dever analisar um número (tipo number)', (t) => {
+test('Deve analisar um número (tipo number)', (t) => {
   t.deepEqual(parseNumber(3.14), { isNegative: false, integer: '3', decimal: '14' })
 })

--- a/src/write-all.js
+++ b/src/write-all.js
@@ -75,7 +75,7 @@ export default (num, opts) => {
     throw new Error('Invalid option')
   }
 
-  const decimalSeparatorIsDot = opts.number.decimalSeparator === 'dot'
+  const decimalSeparatorIsDot = opts.number.decimalSeparator === 'dot' || typeof num === 'number'
 
   if (!isValidNumber(num, decimalSeparatorIsDot)) {
     throw new Error('Invalid number')
@@ -86,7 +86,8 @@ export default (num, opts) => {
   if (opts.mode === 'currency') {
     const iso = opts.currency.type
     const locale = opts.locale
-    const numText = writeCurrency(iso, locale, integer, decimal, opts.scale)
+    const decimalCents = decimal.slice(0, 2)
+    const numText = writeCurrency(iso, locale, integer, decimalCents, opts.scale)
 
     return isNegative
       ? toNegative(numText, opts.negative)

--- a/src/write-all.test.js
+++ b/src/write-all.test.js
@@ -47,6 +47,7 @@ test('Deve escrever valores monetários por extenso', (t) => {
   t.is(writeAll('-2', { mode: 'currency' }), 'dois reais negativo')
   t.is(writeAll('-2', { mode: 'currency', negative: 'informal' }), 'menos dois reais')
   t.is(writeAll('3,50', { mode: 'currency' }), 'três reais e cinquenta centavos')
+  t.is(writeAll(1882.666, { mode: 'currency' }), 'mil oitocentos e oitenta e dois reais e sessenta e seis centavos')
   t.is(writeAll('17', { mode: 'currency' }), 'dezessete reais')
   t.is(writeAll('17', { mode: 'currency', locale: 'pt' }), 'dezassete reais')
   t.is(writeAll('1000000', { mode: 'currency' }), 'um milhão de reais')


### PR DESCRIPTION
Ao refatorar um projeto antigo, me deparei com o problema citado na issue #60. A versão do pacote utilizada no meu projeto atual é a `^2.0.1`.

A função mostrada abaixo, retornava o erro `Invalid number` para valores decimais.

![image](https://github.com/user-attachments/assets/a597bbbb-70a0-4f81-a507-87465b996359)

Sendo assim, fiz as seguintes alterações:

- Adicionei a condição `typeof num === 'number'` na constante abaixo:

```js
const decimalSeparatorIsDot = opts.number.decimalSeparator === 'dot' || typeof num === 'number'
```

Fiz essa alteração devido ao fato do separador padrão do `JavaScript` ser o `.` para valores numéricos.

- Corrigi as casas decimais dos valores referentes aos `centavos` para `mode: "currency"`:

```js
    const decimalCents = decimal.slice(0, 2)
```

Essa alteração limita os `centavos` em duas casas, escrevendo o valor `1882.666` como `mil oitocentos e oitenta e dois reais e sessenta e seis centavos` ao invés de `mil oitocentos e oitenta e dois reais e seiscentos e sessenta e seis centavos`